### PR TITLE
Initialize AlienClient with type-state pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,7 @@ async fn main_loop(metrics: Arc<Metrics>) -> Result<(), AlienError> {
     let one_sec = tokio::time::Duration::from_secs(1);
     let sleep_interval = tokio::time::Duration::from_secs(15);
 
-    let mut alien_client = AlienClient {
-        ..Default::default()
-    };
-
-    alien_client.init().await?;
+    let mut alien_client = AlienClient::new().await?;
 
     loop {
         metrics.scrape_counter.inc();


### PR DESCRIPTION
This makes it harder to create a non-working `AlienClient`. E.g. by forgetting to initialize it. Now the only way to get a client is through the constructor that initializes it automatically.