### PR TITLE
CI: Add GitHub Actions for checks, lints, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+jobs:
+  checks:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.60.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: common
+      - name: Cargo check
+        run: cargo check --workspace
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: common
+      - name: Install cargo-machete
+        run: cargo install --locked cargo-machete
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Cargo doc
+        run: cargo doc --workspace --no-deps
+      - name: Cargo clippy
+        run: cargo clippy --workspace --tests -- -D warnings
+      - name: Cargo machete
+        run: cargo machete
+
+  tests:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [checks, lints]
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.60.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: common
+      - name: Cargo test
+        run: cargo test --workspace


### PR DESCRIPTION
This configuration runs `cargo check` and `cargo test` on a matrix of Rust versions. Stable for obvious reasons, and 1.60.0 because it's the oldest version that builds the project successfully.

The reason for using beta is subtle, but it has to do with attempting to catch breaking compiler changes before they hit stable. It is very rare for this to happen. And when it does, it is usually because some dependency relied on code that was unsound. In these cases, `cargo update` to update all transitive dependencies and generate a new lock file should fix it.

There is also a cron job that runs the workflow weekly, which is necessary for testing the latest stable and beta compilers (especially for a project that doesn't update often).

Testing on the oldest compiler is part of an ["MSRV"](https://github.com/rust-lang/api-guidelines/discussions/231) strategy. The version _will_ have to be bumped as the project evolves and pulls in new dependencies that use newer features. It's just part of the maintenance burden.

All that said, you may choose to not test on beta or an older compiler. It's up to you!